### PR TITLE
Update bot version for Eclipse Menu compatibility

### DIFF
--- a/src/gdr/gdr.hpp
+++ b/src/gdr/gdr.hpp
@@ -14,7 +14,7 @@ cocos2d::CCPoint dataFromString(std::string dataString);
 
 std::vector<std::string> splitByChar(std::string str, char splitChar);
 
-const std::string xdBotVersion = "v2.3.11";
+const std::string xdBotVersion = "2.3.11";
 
 namespace gdr {
 


### PR DESCRIPTION
If you have a string in the bot version, it causes Eclipse to crash your game when you load an xdBot macro. So this pull request fixes that by removing the string.